### PR TITLE
fuzz: add fuzz tests and CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,29 @@ jobs:
         with:
           command: test
           args: --no-default-features --features alloc
+  test-fuzz:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust: [1.70.0]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Run fuzz tests -- Cursor (no_std)
+        run: cargo fuzz run -s none fuzz_cursor -- -runs=10000000
+
+      - name: Run fuzz tests -- Read (no_std)
+        run: cargo fuzz run -s none fuzz_read -- -runs=10000000
+
+      - name: Run fuzz tests -- Write (no_std)
+        run: cargo fuzz run -s none fuzz_write -- -runs=10000000

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "no_std_io-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.no_std_io]
+path = ".."
+features = ["alloc"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "fuzz_read"
+path = "fuzz_targets/fuzz_read.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_write"
+path = "fuzz_targets/fuzz_write.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cursor"
+path = "fuzz_targets/fuzz_cursor.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_cursor.rs
+++ b/fuzz/fuzz_targets/fuzz_cursor.rs
@@ -1,0 +1,26 @@
+#![no_main]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use libfuzzer_sys::fuzz_target;
+use no_std_io::io::{Cursor, Seek, SeekFrom, Write};
+
+fuzz_target!(|data: &[u8]| {
+    let len = data.len();
+    let mut pos = len / 2;
+
+    let mut dest: Vec<u8> = Vec::with_capacity(len);
+    dest.resize(len, 0);
+
+    let mut cursor = Cursor::new(dest);
+
+    cursor.seek(SeekFrom::End(-(pos as i64))).unwrap();
+
+    while pos < len {
+        let bytes_written = cursor.get_mut().write(&data[pos..]).unwrap();
+
+        pos += bytes_written;
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_read.rs
+++ b/fuzz/fuzz_targets/fuzz_read.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use no_std_io::io::Read;
+
+fuzz_target!(|data: &[u8]| {
+    let mut src = data.clone();
+
+    let mut dest: Vec<u8> = Vec::with_capacity(data.len());
+    dest.resize(data.len(), 0);
+
+    let _ = src.read_exact(&mut dest[..data.len()]);
+});

--- a/fuzz/fuzz_targets/fuzz_write.rs
+++ b/fuzz/fuzz_targets/fuzz_write.rs
@@ -1,0 +1,18 @@
+#![no_main]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use libfuzzer_sys::fuzz_target;
+use no_std_io::io::Write;
+
+fuzz_target!(|data: &[u8]| {
+    let mut pos = 0;
+    let mut buffer = Vec::with_capacity(data.len()); 
+    
+    while pos < data.len() {
+        let bytes_written = buffer.write(&data[pos..]).unwrap();
+        pos += bytes_written;
+    }
+});


### PR DESCRIPTION
Adds fuzz targets for `Read/Write` traits, and the `Cursor` struct.

Adds a CI runner to run the fuzz tests for 10M iterations (takes about 2 seconds for each target).